### PR TITLE
fix: webpack v5 support

### DIFF
--- a/lib/attributeParser.js
+++ b/lib/attributeParser.js
@@ -113,8 +113,7 @@ AttributeContext.prototype.resolveAttributes = function (content) {
         var url = self.data[match].value;
         
         // Make resource available through file-loader
-        var fallbackLoader = require.resolve('../file-loader.js') + '?url=' + encodeURIComponent(url);
-        return "' + require(" + JSON.stringify(fallbackLoader + '!' + loaderUtils.urlToRequest(url, self.root)) + ") + '";
+        return "' + require(" + JSON.stringify(loaderUtils.urlToRequest(url, self.root)) + ") + '";
     });
 };
 


### PR DESCRIPTION
With webpack v5, this module does not seem to work properly. The problem happens when external assets (like images) are required by the template. The resulting assets seem to be corrupted (at least for .png's).

This could be due to the fact that the `file-loader` was replaced by `asset/resource` in webpack v5.

Also, this module contains a "fallback" `file-loader.js` file which is used when there are no loaders for this type of asset. However, it looks like it's now broken in webpack v5, and the fact that there's this fallback loader prevents `asset/resource` from requiring the asset properly.

To fix this, we simply remove this fallback loader from this module. It's never actually used in practice anyway.

There's a PR on the source repo to properly support webpack v5 (https://github.com/emaphp/underscore-template-loader/pull/42), but it's not worth the trouble as our use of this module is very basic. And we'll probably remove it at some point.
